### PR TITLE
feat: add implementation authorization type implicit

### DIFF
--- a/client/server.go
+++ b/client/server.go
@@ -1,22 +1,10 @@
 package client
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"net/http"
-	"time"
-
-	"github.com/zeihanaulia/simple-oauth2/pkg/simplestr"
 
 	"github.com/zeihanaulia/simple-oauth2/pkg/simplehttp"
-
-	"github.com/zeihanaulia/simple-oauth2/pkg/randomstring"
-
-	"github.com/zeihanaulia/simple-oauth2/pkg/simpleurl"
 )
-
-var states = make([]string, 0)
-var clientsToken = make(map[string]interface{}, 0)
 
 // Server client service
 type Server struct {
@@ -39,138 +27,9 @@ func (s *Server) Run() error {
 func (s *Server) createServerMux() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.index)
-	mux.HandleFunc("/authorize", s.authorize)
-	mux.HandleFunc("/callback", s.callback)
-	mux.HandleFunc("/fetch_resource", s.fetch_resource)
 	return mux
 }
 
 func (s *Server) index(w http.ResponseWriter, r *http.Request) {
 	simplehttp.HTMLRender(w, "client/templates/index.html", tokenInfo)
-}
-
-func (s *Server) authorize(w http.ResponseWriter, r *http.Request) {
-	var state = randomstring.Generator(32)
-	states = append(states, state) // save state for comparing in callback request
-
-	// don't cache authorize request
-	w.Header().Set("Cache-Control", "no-cache, private, max-age=0")
-	w.Header().Set("Expires", time.Unix(0, 0).Format(http.TimeFormat))
-	w.Header().Set("Pragma", "no-cache")
-	w.Header().Set("X-Accel-Expires", "0")
-
-	http.Redirect(w, r, simpleurl.Builder(authServerInfo.AuthorizationEndpoint, map[string]string{
-		"response_type": "code",
-		"client_id":     "oauth-client-1",
-		"redirect_uri":  "http://localhost:8081/callback",
-		"state":         state,
-	}), 301)
-}
-
-type HTTPResponse struct {
-	Error string
-}
-
-type CallbackResponse struct {
-	AccessToken  string `json:"access_token,omitempty"`
-	RefreshToken string `json:"refresh_token,omitempty"`
-	Scope        string `json:"scope,omitempty"`
-}
-
-func (s *Server) callback(w http.ResponseWriter, r *http.Request) {
-
-	state, ok := r.URL.Query()["state"]
-	if !ok || len(state[0]) <= 1 {
-		w.WriteHeader(http.StatusBadRequest)
-		simplehttp.HTMLRender(w, "client/templates/error.html", HTTPResponse{Error: "Unable to fetch access token, server response: 400"})
-		return
-	}
-
-	if !simplestr.Contains(states, state[0]) {
-		w.WriteHeader(http.StatusBadRequest)
-		simplehttp.HTMLRender(w, "client/templates/error.html", HTTPResponse{Error: "Unable to fetch access token, server response: 400"})
-		return
-	}
-	deleteState(states, state[0]) // remove state
-
-	code, ok := r.URL.Query()["code"]
-	if !ok || len(code[0]) <= 1 {
-		w.WriteHeader(http.StatusBadRequest)
-		simplehttp.HTMLRender(w, "client/templates/error.html", HTTPResponse{Error: "Unable to fetch access token, server response: 400"})
-		return
-	}
-
-	requestBody, _ := json.Marshal(map[string]string{
-		"grant_type":   "authorization_code",
-		"code":         code[0],
-		"redirect_uri": "http://localhost:8081/callback",
-	})
-
-	basicAuthEnc := base64.URLEncoding.EncodeToString([]byte(authServerInfo.ClientID + ":" + authServerInfo.ClientSecret))
-	headers := map[string]string{
-		"Content-type":  "application/json",
-		"Authorization": "Basic " + basicAuthEnc,
-	}
-
-	resp, err := simplehttp.Post(authServerInfo.TokenEndpoint, headers, requestBody)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		simplehttp.HTMLRender(w, "client/templates/error.html", HTTPResponse{Error: "Unable to fetch access token, server response: 400"})
-		return
-	}
-
-	var cr CallbackResponse
-	_ = json.Unmarshal(resp, &cr)
-
-	clientsToken[authServerInfo.ClientID] = map[string]interface{}{
-		"access_token":  cr.AccessToken,
-		"refresh_token": cr.RefreshToken,
-		"scope":         cr.Scope,
-	}
-
-	simplehttp.HTMLRender(w, "client/templates/index.html", Token{
-		AccessToken:  cr.AccessToken,
-		RefreshToken: cr.RefreshToken,
-		Scope:        cr.Scope,
-	})
-}
-
-func deleteState(states []string, accessToken string) []string {
-	var key int
-	for k, v := range states {
-		if v == accessToken {
-			key = k
-		}
-	}
-	states[key] = states[len(states)-1]
-	states[len(states)-1] = ""
-	states = states[:len(states)-1]
-	return states
-}
-
-type ResourceResponse struct {
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
-}
-
-func (s *Server) fetch_resource(w http.ResponseWriter, r *http.Request) {
-
-	token := clientsToken[authServerInfo.ClientID].(map[string]interface{})
-
-	headers := map[string]string{
-		"Content-type": "application/json",
-		"Authorization": "Bearer " + token["access_token"].(string),
-	}
-
-	resp, err := simplehttp.Post("http://localhost:8083/resource", headers, []byte(``))
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		simplehttp.HTMLRender(w, "client/templates/error.html", HTTPResponse{Error: "Unable to fetch access token, server response: 400"})
-		return
-	}
-
-	var rr ResourceResponse
-	_ = json.Unmarshal(resp, &rr)
-
-	simplehttp.HTMLRender(w, "client/templates/data.html", rr)
 }

--- a/client/templates/index.html
+++ b/client/templates/index.html
@@ -8,15 +8,15 @@
     <title>OAuth in Action: OAuth Client</title>
 
     <!-- Bootstrap -->
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-	<style>
-	body {
-	  padding-top: 60px;
-	}
-	.navbar-inverse {
-		background-color: #223;
-	}
-	</style>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+  <style>
+  body {
+    padding-top: 60px;
+  }
+  .navbar-inverse {
+    background-color: #223;
+  }
+  </style>
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
@@ -37,20 +37,127 @@
     <div class="container">
 
       <div class="jumbotron">
-		  <p>Access token value: <span class="label label-danger">{{if .AccessToken}} {{ .AccessToken }} {{else}} NONE {{end}}</span></p>
-		  <p>Scope value: <span class="label label-danger">{{if .Scope}} {{ .Scope }} {{else}} NONE {{end}}</span></p>
-		  <p>Refresh token value: <span class="label label-danger">{{if .RefreshToken}} {{ .RefreshToken }} {{else}} NONE {{end}}</span></p>
-		  <a class="btn btn-default" href="/authorize">Get OAuth Token</a> 
-		  <a class="btn btn-default" href="/fetch_resource">Get Protected Resource</a> 
+      <p>Scope value: <span class="label label-danger oauth-scope-value"></span></p>
+      <p>Access token value: <span class="label label-danger oauth-access-token"></span></p>
+      <button class="btn btn-default oauth-authorize" type="button">Get OAuth Token</button> 
+      <button class="btn btn-default oauth-fetch-resource" type="button">Get Protected Resource</button>
       </div>
-
+      <div class="jumbotron">
+      <h2>Data from protected resource:</h2>
+      <pre><span class="oauth-protected-resource"</pre>
+      </div>
     </div><!-- /.container -->
 
-	
-	
+  
+  
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+
+    <script>
+
+      (function () {
+        var callbackData;
+
+        // client information
+        var client = {
+          'client_id': 'oauth-client-1',
+          'redirect_uris': ['http://localhost:8081/callback'],
+          'scope': 'foo bar'
+        };
+
+        // authorization server information
+        var authServer = {
+          authorizationEndpoint: 'http://localhost:8082/authorize'
+        };
+
+        var protectedResource = 'http://localhost:8083/resource';
+
+        function generateState(len) {
+          var ret = '';
+          var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+          for (var i=0; i < len; i++) {
+            // add random character
+            ret += possible.charAt(Math.floor(Math.random() * possible.length));  
+          }
+          
+          return ret;
+        }  
+
+        function handleAuthorizationRequestClick(ev) {
+          var state = generateState(32);
+
+          localStorage.setItem('oauth-state', state);
+
+          location.href = authServer.authorizationEndpoint + '?' + 
+            'response_type=token' +
+            '&state=' + state +
+            '&scope=' + encodeURIComponent(client.scope) + 
+            '&client_id=' + encodeURIComponent(client.client_id) +
+            '&redirect_uri=' + encodeURIComponent(client.redirect_uris[0]);
+        }
+
+        function handleFetchResourceClick(ev) {
+          if (callbackData != null ) {
+            console.log("callbackData.access_token")
+            console.log(callbackData.access_token)
+            $.ajax({
+              url: protectedResource,
+              type: 'POST',
+              crossDomain: true,
+              dataType: 'json',
+              headers: {
+                'Authorization': 'Bearer ' + callbackData.access_token
+              }
+            }).done(function(data) {
+              $('.oauth-protected-resource').text(JSON.stringify(data));
+            }).fail(function() {
+              $('.oauth-protected-resource').text('Error while fetching the protected resource');
+            });
+
+          }
+        }
+
+        function processCallback() {
+          var h = location.hash.substring(1);
+          var whitelist = ['access_token', 'state']; // for parameters
+
+          callbackData = {};
+
+          h.split('&').forEach(function (e) {
+            var d = e.split('=');
+
+            if (whitelist.indexOf(d[0]) > -1) {
+              callbackData[d[0]] = d[1];  
+            }
+          });
+          
+          if (callbackData.state !== localStorage.getItem('oauth-state')) {
+            console.log('State DOES NOT MATCH: expected %s got %s', localStorage.getItem('oauth-state'), callbackData.state);
+            callbackData = null;
+            $('.oauth-protected-resource').text("Error state value did not match");
+          } else {
+            $('.oauth-access-token').text(callbackData.access_token);
+            console.log('access_token: ', callbackData.access_token);
+          }
+        }
+
+        // fill placeholder on UI
+        $('.oauth-scope-value').text(client.scope);
+
+        // UI button click handler
+        $('.oauth-authorize').on('click', handleAuthorizationRequestClick);
+        $('.oauth-fetch-resource').on('click', handleFetchResourceClick);
+        
+        // we got a hash as a callback
+        if (location.hash) {
+          processCallback();
+        }
+
+      }());
+            
+    </script>
   </body>
 </html>

--- a/services/authorization/server.go
+++ b/services/authorization/server.go
@@ -189,11 +189,7 @@ func (s *Server) approve(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		http.Redirect(w, r, simpleurl.Builder(redirectURI, map[string]string{
-			"access_token": accessToken,
-			"token_type":   "Bearer",
-			"scope":        "",
-		}), 301)
+		http.Redirect(w, r, "http://localhost:8081/callback#access_token="+accessToken+"&scope=&token_type=Bearer&state="+state, 301)
 		return
 	}
 


### PR DESCRIPTION
Implicit grant type biasanya digunakan ketika client hanya ada di browser, misalnya Single Page Application atau mobile app. Implicit pendekatan yang beresiko dikarenakan mengekspos token di sisi client.

Bedanya dengan Code grant type, alih alih menggunakan endpoint token, implicit akan meminta ketika proses approval oleh resource owner.

Ada batasan dalam menggunakan pendekatan ini

1. Tidak ada cara yang realistis untuk menyimpan token di sisi client.

    Since this flow uses only the authorization endpoint and not the token endpoint, this limitation does not affect its ability to function, as the client is never expected to authenticate at the authorization endpoint.

2. Tidak bisa menggunakan refresh token 

    Since in-browser applications are by nature short lived, lasting only the session length of the browser context that has loaded them, the usefulness of a refresh token would be very limited.

Tapi jika diasumsikan bahwa pengguna tetap ada dihalaman itu tidak masalah untuk melakukan reauthorize.